### PR TITLE
Depend on cl-lib 0.5, not 1.0

### DIFF
--- a/synosaurus-pkg.el
+++ b/synosaurus-pkg.el
@@ -1,6 +1,6 @@
 (define-package "synosaurus" "0.1.0"
   "An extensible thesaurus supporting lookup and substitution."
 
-  '((cl-lib "1.0"))
+  '((cl-lib "0.5))
 
   :url "https://github.com/rootzlevel/synosaurus")


### PR DESCRIPTION
1.0 is not installable from any package archive, so although it
is the version number in the cl-lib.el bundled with Emacs,
dependencies should always be on the latest version in GNU ELPA,
which is currently 0.5.